### PR TITLE
Add editable=False to deleted_at field declaration to exclude from django-admin

### DIFF
--- a/timestamps/models.py
+++ b/timestamps/models.py
@@ -12,7 +12,7 @@ class Timestampable(models.Model):
 
 
 class SoftDeletes(models.Model):
-    deleted_at = models.DateTimeField(null=True)
+    deleted_at = models.DateTimeField(null=True, editable=False)
 
     objects = SoftDeleteManager()
     objects_deleted = SoftDeleteManager(only_deleted=True)


### PR DESCRIPTION
Fixes https://github.com/xgeekshq/django-timestampable/issues/3

deleted_at no longer shows up as a field:
<img width="1174" alt="Screen Shot 2022-03-31 at 11 27 09 AM" src="https://user-images.githubusercontent.com/1289653/161124751-665b581c-6563-4dd1-a110-d6edec2efa42.png">

